### PR TITLE
Add support for custom OpenAI API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ By default, the web UI runs on port 5000. Access via <http://localhost:5000>.
 
 ## ⚙️ Configuration
 
-| Variable         | Description                                        | Default     |
-|------------------|----------------------------------------------------|-------------|
-| `OPENAI_API`     | Your OpenAI API key                                | (required)  |
-| `OPENAI_BASE_URL`| OpenAI API base URL (for compatible endpoints)     | `https://api.openai.com/v1` |
-| `OPENAI_MODEL`   | GPT model to use (e.g. `gpt-4.5`)                  | `gpt-4.5`   |
-| `WEBUI_USERNAME` | Username for HTTP Basic Auth                      | (required)  |
-| `WEBUI_PASSWORD` | Password for HTTP Basic Auth                      | (required)  |
+| Variable           | Description                                      | Default                         |
+|--------------------|--------------------------------------------------|---------------------------------|
+| `OPENAI_API`       | Your OpenAI API key                              | (required)                      |
+| `OPENAI_BASE_URL`  | OpenAI API base URL (for compatible endpoints)   | `https://api.openai.com/v1`     |
+| `OPENAI_MODEL`     | GPT model to use (e.g. `gpt-4.5`)                | `gpt-4.5`                       |
+| `WEBUI_USERNAME`   | Username for HTTP Basic Auth                     | (required)                      |
+| `WEBUI_PASSWORD`   | Password for HTTP Basic Auth                     | (required)                      |
 
 Transcripts are read from `output-transcriptions/`. AI-processed
 files land in `AI-Processed-Transcriptions/` and summaries in `AI-Summary/`.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ By default, the web UI runs on port 5000. Access via <http://localhost:5000>.
 | Variable         | Description                                        | Default     |
 |------------------|----------------------------------------------------|-------------|
 | `OPENAI_API`     | Your OpenAI API key                                | (required)  |
+| `OPENAI_BASE_URL`| OpenAI API base URL (for compatible endpoints)     | `https://api.openai.com/v1` |
 | `OPENAI_MODEL`   | GPT model to use (e.g. `gpt-4.5`)                  | `gpt-4.5`   |
 | `WEBUI_USERNAME` | Username for HTTP Basic Auth                      | (required)  |
 | `WEBUI_PASSWORD` | Password for HTTP Basic Auth                      | (required)  |

--- a/env.example
+++ b/env.example
@@ -1,6 +1,7 @@
 SHINAR_MODEL=medium
 SHINAR_LOW_MODEL=base
 OPENAI_API=your_key_goes_here
+OPENAI_BASE_URL=https://api.openai.com/v1
 OPENAI_MODEL=gpt-4.1
 WEBUI_USERNAME=admin
 WEBUI_PASSWORD=admin

--- a/shinar.py
+++ b/shinar.py
@@ -12,6 +12,7 @@ with each segment labeled by speaker.
 """
 import os
 import time
+
 # Load .env file for environment configuration
 ENV_FILE = os.path.join(os.getcwd(), ".env")
 if os.path.exists(ENV_FILE):
@@ -22,15 +23,14 @@ if os.path.exists(ENV_FILE):
                 continue
             key, val = line.split("=", 1)
             os.environ.setdefault(key, val)
-from watchdog.observers import Observer
-from watchdog.events import PatternMatchingEventHandler
-
-import whisper
-import torch
 import numpy as np
-from whisper import audio as whisper_audio
+import torch
+import whisper
 from resemblyzer import VoiceEncoder
 from sklearn.cluster import AgglomerativeClustering
+from watchdog.events import PatternMatchingEventHandler
+from watchdog.observers import Observer
+from whisper import audio as whisper_audio
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 # sample rate used by Whisper (Hz)
@@ -160,6 +160,7 @@ if __name__ == "__main__":
 
     # model and speaker count settings (defaults from .env via SHINAR_MODEL and SHINAR_LOW_MODEL)
     import argparse
+
     # Read model defaults from environment, fallback to small/tiny
     env_high = os.environ.get("SHINAR_MODEL", "small")
     env_low = os.environ.get("SHINAR_LOW_MODEL", "tiny")

--- a/start.py
+++ b/start.py
@@ -8,10 +8,11 @@ Usage:
 Any arguments are forwarded to shinar.py.
 """
 import os
+import signal
 import subprocess
 import sys
 import time
-import signal
+
 
 def main():
     """

--- a/webui.py
+++ b/webui.py
@@ -4,6 +4,7 @@ Web UI for Shinar speaker-diarized transcriptions.
 """
 import os
 import sys
+
 # Load .env for environment variables (e.g., WEBUI_USERNAME, WEBUI_PASSWORD)
 ENV_FILE = os.path.join(os.getcwd(), '.env')
 if os.path.exists(ENV_FILE):
@@ -19,9 +20,11 @@ if os.path.exists(ENV_FILE):
                 val = val[1:-1]
             os.environ.setdefault(key, val)
 
-from flask import Flask, render_template_string, abort, jsonify, request, Response
-from datetime import datetime
 import subprocess
+from datetime import datetime
+
+from flask import Flask, Response, abort, jsonify, render_template_string, request
+
 # Directory containing transcription Markdown files
 OUTPUT_DIR = os.path.join(os.getcwd(), 'output-transcriptions')
 # Directory containing original audio files


### PR DESCRIPTION
Introduce the ability to configure a custom OpenAI API base URL, enhancing flexibility for users. Update the README to reflect this new configuration option. Clean up import statements for better code organization.

Possibly solves #1